### PR TITLE
fullCheck parameter is case-sensitive

### DIFF
--- a/src/Account.php
+++ b/src/Account.php
@@ -194,7 +194,7 @@ class Account extends RestEntry {
         $data = ["TnList" => ["Tn" => $array ]];
         $obj = new \Iris\NumberPortabilityRequest($data);
         if($fullcheck !== false && in_array($fullcheck, ["true", "false", "onnetportability", "offnetportability"])) {
-            $f = "?fullcheck=$fullcheck";
+            $f = "?fullCheck=$fullcheck";
         } else {
             $f = "";
         }

--- a/tests/AccountTest.php
+++ b/tests/AccountTest.php
@@ -141,7 +141,7 @@ class AccountTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($json, json_encode($res->to_array()));
 
         $this->assertEquals("POST", self::$container[self::$index]['request']->getMethod());
-        $this->assertEquals("https://api.test.inetwork.com/v1.0/accounts/9500249/lnpchecker?fullcheck=true", self::$container[self::$index]['request']->getUri());
+        $this->assertEquals("https://api.test.inetwork.com/v1.0/accounts/9500249/lnpchecker?fullCheck=true", self::$container[self::$index]['request']->getUri());
         self::$index++;
     }
     public function testNpaGet() {


### PR DESCRIPTION
The `fullCheck` parameter for the lnpchecker is case-sensitive. Any value passed to the `Account::lnpChecker`'s `$fullcheck` argument was being ignored by the server.